### PR TITLE
custom debug configuration support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "xmake-vscode",
     "displayName": "XMake",
     "description": "Extended XMake support in Visual Studio Code",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "publisher": "tboox",
     "icon": "res/logo256.png",
     "repository": {
@@ -325,6 +325,23 @@
                         "default": []
                     },
                     "description": "The Debugging Targets Arguments, .e.g {\"targetName\": [\"args\", \"...\"]}"
+                },
+                "xmake.debugConfigType": {
+                    "type": "string",
+                    "default": "default",
+                    "enum": [
+                        "default",
+                        "codelldb",
+                        "custom"
+                    ],
+                    "description": "The Debugging Configuration Type, .e.g default|codelldb|custom"
+                },
+                "xmake.customDebugConfig": {
+                    "type": "object",
+                    "default": {
+                        "type": "cppdbg"
+                    },
+                    "description": "The Custom Debugging Configurations when xmake.debugConfigType is custom"
                 }
             }
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,14 @@ export class Config {
     get debuggingTargetsArguments(): {} {
         return this.get<{}>("debuggingTargetsArguments");
     }
+
+    get debugConfigType(): string {
+        return utils.replaceVars(this.get<string>("debugConfigType"));
+    }
+
+    get customDebugConfig(): {} {
+        return this.get<{}>("customDebugConfig");
+    }
 }
 
 // init the global config

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -6,8 +6,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as encoding from 'encoding';
-import {log} from './log';
-import {config} from './config';
+import { log } from './log';
+import { config } from './config';
 
 // the debugger class
 export class Debugger implements vscode.Disposable {
@@ -28,7 +28,7 @@ export class Debugger implements vscode.Disposable {
 
         // no target program?
         if (!targetProgram) {
-            return ;
+            return;
         }
 
         // no target name? get it from target program
@@ -42,57 +42,78 @@ export class Debugger implements vscode.Disposable {
             args = config.debuggingTargetsArguments[targetName];
         else if ("default" in config.debuggingTargetsArguments)
             args = config.debuggingTargetsArguments["default"];
-        
+
         // init debug configuration
         var debugConfig: vscode.DebugConfiguration = null
-        if (os.platform() == "darwin") {
+        if (config.debugConfigType == "codelldb") {
             debugConfig = {
                 name: `launch: ${targetName}`,
-                type: 'cppdbg',
+                type: 'lldb',
                 request: 'launch',
                 program: targetProgram,
                 args: args,
                 stopAtEntry: true,
                 cwd: path.dirname(targetProgram),
                 environment: [],
-                externalConsole: true,
-                MIMode: "lldb",
-                miDebuggerPath: ""
+                externalConsole: false,
             };
-        } else if (os.platform() == "linux") {
-            debugConfig = {
-                name: `launch: ${targetName}`,
-                type: 'cppdbg',
-                request: 'launch',
-                program: targetProgram,
-                args: args,
-                stopAtEntry: true,
-                cwd: path.dirname(targetProgram),
-                environment: [],
-                externalConsole: true,
-                MIMode: "gdb",
-                miDebuggerPath: "",
-                description: "Enable pretty-printing for gdb",
-                text: "-enable-pretty-printing",
-                ignoreFailures: true
-            };
-        } else if (os.platform() == "win32") {
-            debugConfig = {
-                name: `launch: ${targetName}`,
-                type: 'cppvsdbg',
-                request: 'launch',
-                program: targetProgram,
-                args: [],
-                stopAtEntry: true,
-                cwd: path.dirname(targetProgram),
-                environment: [],
-                externalConsole: true,
-                MIMode: "gdb",
-                miDebuggerPath: "",
-                description: "Enable pretty-printing for gdb",
-                text: "-enable-pretty-printing",
-                ignoreFailures: true
-            };
+        } else {
+            if (os.platform() == "darwin") {
+                debugConfig = {
+                    name: `launch: ${targetName}`,
+                    type: 'cppdbg',
+                    request: 'launch',
+                    program: targetProgram,
+                    args: args,
+                    stopAtEntry: true,
+                    cwd: path.dirname(targetProgram),
+                    environment: [],
+                    externalConsole: true,
+                    MIMode: "lldb",
+                    miDebuggerPath: ""
+                };
+            } else if (os.platform() == "linux") {
+                debugConfig = {
+                    name: `launch: ${targetName}`,
+                    type: 'cppdbg',
+                    request: 'launch',
+                    program: targetProgram,
+                    args: args,
+                    stopAtEntry: true,
+                    cwd: path.dirname(targetProgram),
+                    environment: [],
+                    externalConsole: true,
+                    MIMode: "gdb",
+                    miDebuggerPath: "",
+                    description: "Enable pretty-printing for gdb",
+                    text: "-enable-pretty-printing",
+                    ignoreFailures: true
+                };
+            } else if (os.platform() == "win32") {
+                debugConfig = {
+                    name: `launch: ${targetName}`,
+                    type: 'cppvsdbg',
+                    request: 'launch',
+                    program: targetProgram,
+                    args: [],
+                    stopAtEntry: true,
+                    cwd: path.dirname(targetProgram),
+                    environment: [],
+                    externalConsole: true,
+                    MIMode: "gdb",
+                    miDebuggerPath: "",
+                    description: "Enable pretty-printing for gdb",
+                    text: "-enable-pretty-printing",
+                    ignoreFailures: true
+                };
+            }
+
+            if (config.debugConfigType == "custom") {
+                var customcfg = config.customDebugConfig;
+                for (let key in customcfg) {
+                    debugConfig[key] = customcfg[key];
+                }
+            }
         }
 
         // start debugging


### PR DESCRIPTION
增加自定义调试配置：
xmake.debugConfigType: "default"使用原来配置，"codelldb"使用codelldb插件，"custom"在原来配置的基础上，利用xmake.customDebugConfig进行参数更新。
Fixes #19 