### PR TITLE
Fixes #51

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -107,7 +107,7 @@ export class Debugger implements vscode.Disposable {
                     type: 'cppvsdbg',
                     request: 'launch',
                     program: targetProgram,
-                    args: [],
+                    args: args,
                     stopAtEntry: true,
                     cwd: targetRunDir,
                     environment: [],


### PR DESCRIPTION
Updated `debugger.ts` so that arguments derived from `xmake.debuggingTargetsArguments` are used in the `debugConfig` object on Windows, as with other platforms.