### PR TITLE
use integrated terminal on mingw/msys2

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -111,7 +111,7 @@ export class Debugger implements vscode.Disposable {
                     stopAtEntry: true,
                     cwd: targetRunDir,
                     environment: [],
-                    externalConsole: true,
+                    externalConsole: false,
                     MIMode: "gdb",
                     miDebuggerPath: "",
                     description: "Enable pretty-printing for gdb",


### PR DESCRIPTION
The integrated terminal is compatible with mingw/msys2. VS Code cpptools uses it and it's set in xmake-vscode for Linux already so it is maybe a good idea using it where possible.