### PR TITLE
Debug linux平台无法拉起lldb扩展

### DIFF
--- a/src/status.ts
+++ b/src/status.ts
@@ -61,7 +61,7 @@ export class Status implements vscode.Disposable {
 
         // init mode button
         this._modeButton.command = 'xmake.setBuildMode';
-        this._modeButton.text = `release`;
+        this._modeButton.text = `debug`;
         this._modeButton.tooltip = "Set build mode";
 
         // init build button, icons: https://octicons.github.com/

--- a/src/xmake.ts
+++ b/src/xmake.ts
@@ -721,7 +721,7 @@ export class XMake implements vscode.Disposable {
          * https://github.com/vadimcn/vscode-lldb
          */
         var extension = null; 
-        if (os.platform() == "darwin") {
+        if (os.platform() == "darwin" || config.debugConfigType=="codelldb") {
             extension = vscode.extensions.getExtension("vadimcn.vscode-lldb");
         }
         if (!extension) { 

--- a/src/xmake.ts
+++ b/src/xmake.ts
@@ -132,7 +132,7 @@ export class XMake implements vscode.Disposable {
         }
         
         // init build mode
-        const mode = ("mode" in cacheJson && cacheJson["mode"] != "")? cacheJson["mode"] : "release";
+        const mode = ("mode" in cacheJson && cacheJson["mode"] != "")? cacheJson["mode"] : "debug";
         this._option.set("mode", mode);
         this._status.mode = mode;
     }


### PR DESCRIPTION
为了满足mac下优先使用lldb，其他平台手动设置debugtype也能拉起lldb，就这么改了.

第二个开发过程中build mode debug明显次数多于release，所以默认启用debug模式会更加合理一些