### PR TITLE
Allow xmake executable to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ Please see [IntelliSense for cross-compiling](https://code.visualstudio.com/docs
         "type": "object",
         "title": "XMake configuration",
         "properties": {
+            "xmake.executable": {
+                "type": "string",
+                "default": "xmake",
+                "description": "The xmake executable name / path"
+            },
             "xmake.logLevel": {
                 "type": "string",
                 "default": "normal",

--- a/package.json
+++ b/package.json
@@ -278,6 +278,11 @@
       "type": "object",
       "title": "XMake configuration",
       "properties": {
+        "xmake.executable": {
+          "type": "string",
+          "default": "xmake",
+          "description": "The xmake executable name / path"
+        },
         "xmake.logLevel": {
           "type": "string",
           "default": "normal",

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,11 @@ export class Config {
         }
     }
 
+    // the xmake executable name / path
+    get executable(): string {
+        return utils.replaceVars(this.get<string>("executable"));
+    }
+
     // the build directory
     get buildDirectory(): string {
         return utils.replaceVars(this.get<string>("buildDirectory"));

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -29,7 +29,7 @@ export class Debugger implements vscode.Disposable {
         var gdbPath = null;
         let findGdbScript = path.join(__dirname, `../../assets/find_gdb.lua`);
         if (fs.existsSync(findGdbScript)) {
-            gdbPath = (await process.iorunv("xmake", ["l", findGdbScript], {"COLORTERM": "nocolor"}, config.workingDirectory)).stdout.trim();
+            gdbPath = (await process.iorunv(config.executable, ["l", findGdbScript], {"COLORTERM": "nocolor"}, config.workingDirectory)).stdout.trim();
             if (gdbPath) {
                 gdbPath = gdbPath.split('\n')[0].trim();
             }


### PR DESCRIPTION
Add a new `xmake.executable` configuration option that defaults to `xmake` (the old behavior), but can be overridden by-user or by-workspace to allow users to point to a specific EXE.

This is useful for cases where you have a self-contained `xmake` distributed in a manner where it's not configured in your PATH (e.g. kept in VCS with the project to make sure everyone's on the same version), or to easily use a development version of `xmake` in VSCode.