### PR TITLE
解决了调试，命中不了断点的bug

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -139,7 +139,7 @@ export class Debugger implements vscode.Disposable {
             } else if (os.platform() == "win32") {
                 debugConfig = {
                     name: `launch: ${targetName}`,
-                    type: 'cppvsdbg',
+                    type: 'cppdbg', //解决了调试，命中不了断点的bug
                     request: 'launch',
                     program: targetProgram,
                     args: args,


### PR DESCRIPTION
# 一个小问题，解决了调试，命中不了断点的bug  
## 更改内容
debugger.ts     
一个小问题，解决了调试，命中不了断点的bug    
## 测试平台    
win32   
## Vscode版本     
1.66.0   
## 工具链   
gcc  
## xmake.lua配置
```
add_rules("mode.debug", "mode.release")

target("hello")
    set_kind("binary")
    add_files("src/*.c")
    set_toolchains("gcc")
```
