### PR TITLE
fix mode selection

### DIFF
--- a/src/xmake.ts
+++ b/src/xmake.ts
@@ -1036,7 +1036,7 @@ export class XMake implements vscode.Disposable {
                 const chosen: vscode.QuickPickItem|undefined = await vscode.window.showQuickPick(items);
                 if (chosen && chosen.label !== this._option.get<string>("mode")) {
                     this._option.set("mode", chosen.label);
-                    this._status.arch = chosen.label;
+                    this._status.mode = chosen.label;
                     this._optionChanged = true;
                 }
             }


### PR DESCRIPTION
在修改`mode`的时候会错误的修改`arch`的`label`

具体复现

![动画](https://user-images.githubusercontent.com/53591299/171608991-d691a2c4-fecc-486c-90bb-8be8193f6fd1.gif)

