### PR TITLE
fix target.files maybe it's empty

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -219,7 +219,8 @@ class XMakeExplorerDataProvider implements vscode.TreeDataProvider<XMakeExplorer
             targetNode.children.push(new XMakeExplorerHierarchyNode({ type: XMakeExplorerItemType.FILE, group: groups, target: target.name, path: scriptPath }));
 
             // Sort files so that they appear the same when refreshed
-            if (target.files != null) {
+            const filekeys = Object.keys(target.files);
+            if (target.files != null && filekeys.length != 0) {
                 target.files.sort();
             } else {
                 target.files = [];


### PR DESCRIPTION
issue #129
target.files为空时，调用target.files.sort();会出问题，导致插件启动失败。
这个情况当配置文件中set_kind("headeronly")时出现。

