### PR TITLE
fix buildAll/rebuildAll

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -710,10 +710,12 @@ export class XMakeExplorer implements vscode.Disposable {
 
         // Build commands
         vscode.commands.registerCommand('xmakeExplorer.buildAll', () => {
+            vscode.commands.executeCommand("xmake.setTarget", undefined);
             vscode.commands.executeCommand("xmake.onBuild");
         });
 
         vscode.commands.registerCommand('xmakeExplorer.rebuildAll', (item: XMakeExplorerItem) => {
+            vscode.commands.executeCommand("xmake.setTarget", undefined);
             vscode.commands.executeCommand("xmake.onRebuild");
         });
 


### PR DESCRIPTION
**问题描述**：插件 buildAll/rebuildAll 功能不能正确运行，当选择一个 target build 后，后续的 buildAll 都会变成 build 这一个特定的 target

翻了下 issues 好像没有人提到过这个问题？看过源码后发现，无论是 buildAll 还是 build target 调用的都是 xmake.onBuild 命令
```typescript
// src/explorer.ts
        vscode.commands.registerCommand('xmakeExplorer.buildAll', () => {
            vscode.commands.executeCommand("xmake.onBuild");
        });

        vscode.commands.registerCommand('xmakeExplorer.rebuildAll', (item: XMakeExplorerItem) => {
            vscode.commands.executeCommand("xmake.setTarget", undefined);
            vscode.commands.executeCommand("xmake.onRebuild");
        });
```

而决定 build 命令的不是 onBuild 的参数，竟然是从 options 里取
```typescript
        const targetName = this._option.get<string>("target");
        const buildLevel = config.get<string>("buildLevel");
        let command = config.executable;
        if (targetName && targetName != "default")
            command += " build";
...

        // add build target to command
        if (targetName && targetName != "default")
            command += ` ${targetName}`;
        else if (targetName == "all")
            command += " -a";
```

秉承最小原则，仅在 buildAll 前将 option target 设置为 undefined 做修复
```typescript
        vscode.commands.registerCommand('xmakeExplorer.buildAll', () => {
            vscode.commands.executeCommand("xmake.setTarget", undefined);
            vscode.commands.executeCommand("xmake.onBuild");
        });

        vscode.commands.registerCommand('xmakeExplorer.rebuildAll', (item: XMakeExplorerItem) => {
            vscode.commands.executeCommand("xmake.setTarget", undefined);
            vscode.commands.executeCommand("xmake.onRebuild");
        });
```


