### PR TITLE
add force-configure

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "onCommand:xmake.onCreateProject",
     "onCommand:xmake.onNewFiles",
     "onCommand:xmake.onConfigure",
+    "onCommand:xmake.onForceConfigure",
     "onCommand:xmake.onCleanConfigure",
     "onCommand:xmake.onBuild",
     "onCommand:xmake.onRebuild",
@@ -119,7 +120,7 @@
         "category": "XMake"
       },
       {
-        "command": "xmake.onConfigure",
+        "command": "xmake.onForceConfigure",
         "title": "Configure",
         "category": "XMake"
       },
@@ -314,6 +315,9 @@
         },
         {
           "command": "xmake.onConfigure"
+        },
+        {
+          "command": "xmake.onForceConfigure"
         },
         {
           "command": "xmake.onCleanConfigure"

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -766,7 +766,7 @@ export class XMakeExplorer implements vscode.Disposable {
         });
 
         vscode.commands.registerCommand('xmakeExplorer.configure', (item: XMakeExplorerItem) => {
-                vscode.commands.executeCommand("xmake.onConfigure");
+                vscode.commands.executeCommand("xmake.onForceConfigure");
         });
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ export async function activate(context: vscode.ExtensionContext) {
         'onCreateProject',
         'onNewFiles',
         'onConfigure',
+        'onForceConfigure',
         'onCleanConfigure',
         'onBuild',
         'onRebuild',

--- a/src/xmake.ts
+++ b/src/xmake.ts
@@ -509,6 +509,57 @@ export class XMake implements vscode.Disposable {
         return false;
     }
 
+    async onForceConfigure(target?: string): Promise<boolean> {
+
+        // this plugin enabled?
+        if (!this._enabled) {
+            return false;
+        }
+        // get the target platform
+        let plat = this._option.get<string>("plat");
+
+        // get the target architecture
+        let arch = this._option.get<string>("arch");
+
+        // get the build mode
+        let mode = this._option.get<string>("mode");
+
+        // get the toolchain
+        let toolchain = this._option.get<string>("toolchain");
+
+        // make command
+        let command = config.executable
+        var args = ["f", "-p", `${plat}`, "-a", `${arch}`, "-m", `${mode}`];
+        if (this._option.get<string>("plat") == "android" && config.androidNDKDirectory != "") {
+            args.push(`--ndk=${config.androidNDKDirectory}`);
+        }
+        if (config.QtDirectory != "") {
+            args.push(`--qt=${config.QtDirectory}`);
+        }
+        if (config.WDKDirectory != "") {
+            args.push(`--wdk=${config.WDKDirectory}`);
+        }
+        if (config.buildDirectory != "" && config.buildDirectory != path.join(utils.getProjectRoot(), "build")) {
+            args.push("-o");
+            args.push(config.buildDirectory);
+        }
+        if (config.additionalConfigArguments) {
+            for (let arg of config.additionalConfigArguments) {
+                args.push(arg);
+            }
+        }
+        if (toolchain != "toolchain") {
+            args.push("--toolchain=" + toolchain);
+        }
+
+        // configure it
+        await this._terminal.execv("config", command, args);
+
+        // mark as not changed
+        this._optionChanged = false;
+        return true;
+    }
+
     // on clean configure project
     async onCleanConfigure(target?: string) {
 


### PR DESCRIPTION
When XMake: Configure is called manually, the xmake command should run everytimes, even if options has not been changed. Custom options like .vscode/settings.json may not be detected.