### PR TITLE
Add env and terminal configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Debug via launch configurations is accessible only with Run->Start Debugging (no
 |args               |string ❘ [string]| Command line parameters. If not defined args are taken from `debuggingTargetsArguments` config.
 |cwd                |string| If not defined xmake will use the target directory. 
 |stopAtEntry        |boolean| If set to true, the debugger should stop at the entry-point of the target (ignored on attach). Default value is false.
+|terminal           |string| Destination of stdio streams: <ul><li>`console` for Debug Console</li><li>`integrated` (default) for VSCode integrated terminal</li><li>`external` for a new terminal window</li><li>`newExternal` for a new terminal window but only with cli application (only cpptools / with lldb it will be converted to `external`)</li></ul>|
 
 Example:
 ```json
@@ -148,6 +149,18 @@ Example:
   ]
 }
 ```
+
+### Envs behaviour
+
+You can choose the behaviour between xmake envs and envs that are defined in `launch.json`
+For an xmake envs that are like this `{"PATH: "path/from/xmake"}` and in `launch.json` 
+`{"PATH": "path/from/config}`. 
+
+* With `xmake.envBehaviour` set to `merge`, the result is `{"PATH": "path/from/xmake;path/from/config"}`.
+* With `xmake.envBehaviour` set to `erase`, the result is `{"PATH": "path/from/xmake}`
+* And with `xmake.envBehaviour` set to `override`, the result is: `{"PATH": "path/from/config}`.
+
+XMake envs will only be replaced for the same key, if another xmake env key is present, it will be present in the final result.
 
 ## Global Configuration
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Debug via launch configurations is accessible only with Run->Start Debugging (no
 |**type**           |string| *Required.* Set to `xmake`.
 |**request**        |string| *Required.* Session initiation method:`launch` or `attach`.
 |**target**         |string| *Required.* XMake target.
+|env                |object| 	Additional environment variables. `{"PATH" : "some/path"}`
 |args               |string ❘ [string]| Command line parameters. If not defined args are taken from `debuggingTargetsArguments` config.
 |cwd                |string| If not defined xmake will use the target directory. 
 |stopAtEntry        |boolean| If set to true, the debugger should stop at the entry-point of the target (ignored on attach). Default value is false.

--- a/package.json
+++ b/package.json
@@ -476,6 +476,32 @@
                   "string"
                 ],
                 "default": []
+              },
+              "terminal": {
+                "type": "string",
+                "enum": [
+                  "integrated",
+                  "external",
+                  "console",
+                  "newExternal"
+                ],
+                "enumDescriptions": [
+                  "Use integrated terminal in VSCode.",
+                  "Use external terminal window.",
+                  "Use VScode Debug Console for stdout and stderr. Stdin will be unavailable.",
+                  "Use external terminal window for console application, nothing for the others (only with cpptools). "
+                ],
+                "default": "integrated"
+              },
+              "env": {
+                "description": "Additional environment variables.",
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "type": "string"
+                  }
+                },
+                "default": {}
               }
             }
           },
@@ -506,6 +532,32 @@
                   "string"
                 ],
                 "default": []
+              },
+              "terminal": {
+                "type": "string",
+                "enum": [
+                  "integrated",
+                  "external",
+                  "console",
+                  "newExternal"
+                ],
+                "enumDescriptions": [
+                  "Use integrated terminal in VSCode.",
+                  "Use external terminal window.",
+                  "Use VScode Debug Console for stdout and stderr. Stdin will be unavailable.",
+                  "Use external terminal window for console application, nothing for the others (only with cpptools). "
+                ],
+                "default": "integrated"
+              },
+              "env": {
+                "description": "Additional environment variables.",
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "type": "string"
+                  }
+                },
+                "default": {}
               }
             }
           }
@@ -647,6 +699,21 @@
           "type": "object",
           "default": {},
           "description": "The Custom Debugging Configurations"
+        },
+        "xmake.envBehaviour": {
+          "type": "string",
+          "default": "merge",
+          "enum": [
+            "erase",
+            "merge",
+            "override"
+          ],
+          "description": "Environment behaviour between launch.json and xmake envs",
+          "enumDescriptions": [
+            "XMake envs will erase launch.json envs",
+            "This will concat launch.json envs and xmake envs",
+            "Launch configurations will override xmake envs"
+          ]
         }
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,6 +100,10 @@ export class Config {
     get customDebugConfig(): {} {
         return this.get<{}>("customDebugConfig");
     }
+
+    get envBehaviour(): string {
+        return this.get<string>("envBehaviour");
+    }
 }
 
 // init the global config


### PR DESCRIPTION
Add `terminal` and `env` key to `launch.json` as well as `envBehaviour` parameters to choose the behavior between xmake envs and debug configuration.