### PR TITLE
Add diagnostic for xmake.lua using `xmake check`

### DIFF
--- a/src/diagnosis.ts
+++ b/src/diagnosis.ts
@@ -5,9 +5,6 @@ import * as vscode from 'vscode';
 
 const MAX_CHARACTER_NUM = 255;
 
-// handle line break within single quote
-const lineBreakRegex = /(\r\n)(?=([^'\\]*(\\.|'([^'\\]*\\.)*[^'\\]*'))*[^']*$)/;
-
 // e.g. error: .\\include\\xmake.lua:26: global 'add_cflags' is not callable (a nil value)
 const luaOutputRegex = /^([^:]+):\s([^:]+):(\d+):\s(.+)$/;
 
@@ -20,7 +17,7 @@ export function isEligible(filePath: string | undefined): boolean {
 
 export function parse(output: string): vscode.Diagnostic[] {
     const collection: vscode.Diagnostic[] = [];
-    output.split(lineBreakRegex).forEach(outputLine => {
+    output.split("\r\n").forEach(outputLine => {
         if (outputLine) {
             let level = "";
             let file = "";

--- a/src/diagnosis.ts
+++ b/src/diagnosis.ts
@@ -1,0 +1,68 @@
+'use strict';
+
+// imports
+import * as vscode from 'vscode';
+
+const MAX_CHARACTER_NUM = 255;
+
+// handle line break within single quote
+const lineBreakRegex = /(\r\n)(?=([^'\\]*(\\.|'([^'\\]*\\.)*[^'\\]*'))*[^']*$)/;
+
+// e.g. error: .\\include\\xmake.lua:26: global 'add_cflags' is not callable (a nil value)
+const luaOutputRegex = /^([^:]+):\s([^:]+):(\d+):\s(.+)$/;
+
+// e.g. .\\include\\xmake.lua:24: warning: cl: unknown c compiler flag '-ox'
+const xmakeOutputRegex = /^([^:]+):(\d+):\s([^:]+):\s(.+)$/;
+
+export function isEligible(filePath: string | undefined): boolean {
+    return filePath && filePath.includes("xmake.lua") && !filePath.includes(".xmake");
+}
+
+export function parse(output: string): vscode.Diagnostic[] {
+    const collection: vscode.Diagnostic[] = [];
+    output.split(lineBreakRegex).forEach(outputLine => {
+        if (outputLine) {
+            let level = "";
+            let file = "";
+            let line = 0;
+            let message = "";
+            let matches = luaOutputRegex.exec(outputLine);
+            if (matches) {
+                level = matches[1].trim();
+                file = matches[2].trim();
+                line = parseInt(matches[3].trim());
+                message = matches[4].trim();
+            } else {
+                matches = xmakeOutputRegex.exec(outputLine);
+                if (matches) {
+                    file = matches[1].trim();
+                    line = parseInt(matches[2].trim());
+                    level = matches[3].trim();
+                    message = matches[4].trim();
+                }
+            }
+
+            let severity = vscode.DiagnosticSeverity.Hint;
+            if (level == "error") {
+                severity = vscode.DiagnosticSeverity.Error;
+            } else if (level == "warning") {
+                severity = vscode.DiagnosticSeverity.Warning;
+            }
+
+            if (severity == vscode.DiagnosticSeverity.Error ||
+                severity == vscode.DiagnosticSeverity.Warning) {
+                let diag = new vscode.Diagnostic(
+                    new vscode.Range(
+                        new vscode.Position(line - 1, 0), new vscode.Position(line - 1, MAX_CHARACTER_NUM),
+                    ),
+                    message,
+                    severity
+                );
+                diag.source = 'xmake';
+                collection.push(diag);
+            }
+        }
+    });
+
+    return collection;
+}

--- a/src/diagnosis.ts
+++ b/src/diagnosis.ts
@@ -2,13 +2,15 @@
 
 // imports
 import * as vscode from 'vscode';
+import * as os from 'os';
+import { log } from './log';
 
 const MAX_CHARACTER_NUM = 255;
 
-// e.g. error: .\\include\\xmake.lua:26: global 'add_cflags' is not callable (a nil value)
+// e.g. error: .\\xmake.lua:26: global 'add_cflags' is not callable (a nil value)
 const luaOutputRegex = /^([^:]+):\s([^:]+):(\d+):\s(.+)$/;
 
-// e.g. .\\include\\xmake.lua:24: warning: cl: unknown c compiler flag '-ox'
+// e.g. .\\xmake.lua:24: warning: cl: unknown c compiler flag '-ox'
 const xmakeOutputRegex = /^([^:]+):(\d+):\s([^:]+):\s(.+)$/;
 
 export function isEligible(filePath: string | undefined): boolean {
@@ -17,7 +19,8 @@ export function isEligible(filePath: string | undefined): boolean {
 
 export function parse(output: string): vscode.Diagnostic[] {
     const collection: vscode.Diagnostic[] = [];
-    output.split("\r\n").forEach(outputLine => {
+    output.split(os.EOL).forEach(outputLine => {
+        log.verbose("parse Diagnosis: " + outputLine);
         if (outputLine) {
             let level = "";
             let file = "";

--- a/src/xmake.ts
+++ b/src/xmake.ts
@@ -172,7 +172,7 @@ export class XMake implements vscode.Disposable {
 
         log.verbose("updating Diagnosis ..");
         const result = await process.runv(config.executable, ["check", "-F", affectedPath.fsPath], { "COLORTERM": "nocolor" }, config.workingDirectory);
-        const diags = diagnosis.parse(result.stdout);
+        const diags = diagnosis.parse(result.stdout ?? result.stderr);
         this._xmakeDiagnosticCollection.set(affectedPath, diags);
     }
 

--- a/src/xmake.ts
+++ b/src/xmake.ts
@@ -114,6 +114,9 @@ export class XMake implements vscode.Disposable {
         if (this._xmakeExplorer) {
             this._xmakeExplorer.dispose();
         }
+        if (this._xmakeDiagnosticCollection) {
+            this._xmakeDiagnosticCollection.dispose();
+        }
     }
 
     // load cache


### PR DESCRIPTION
This is to add diagnostic info for xmake.lua, when:

1. file is opened
2. file is changed, with 10s cool down, like intellisense

It runs `xmake check -F $file` and parse the output to diagnostic for this file

issue #172 