### PR TITLE
Remove diagnosis from internal files

### DIFF
--- a/src/diagnosis.ts
+++ b/src/diagnosis.ts
@@ -49,8 +49,9 @@ export function parse(output: string): vscode.Diagnostic[] {
                 severity = vscode.DiagnosticSeverity.Warning;
             }
 
-            if (severity == vscode.DiagnosticSeverity.Error ||
-                severity == vscode.DiagnosticSeverity.Warning) {
+            if (isEligible(file) &&
+                (severity == vscode.DiagnosticSeverity.Error ||
+                 severity == vscode.DiagnosticSeverity.Warning)) {
                 let diag = new vscode.Diagnostic(
                     new vscode.Range(
                         new vscode.Position(line - 1, 0), new vscode.Position(line - 1, MAX_CHARACTER_NUM),

--- a/src/diagnosis.ts
+++ b/src/diagnosis.ts
@@ -13,6 +13,10 @@ const luaOutputRegex = /^([^:]+):\s([^:]+):(\d+):\s(.+)$/;
 // e.g. .\\xmake.lua:24: warning: cl: unknown c compiler flag '-ox'
 const xmakeOutputRegex = /^([^:]+):(\d+):\s([^:]+):\s(.+)$/;
 
+function isInternalFile(filePath: string): boolean {
+    return filePath.startsWith("@programdir");
+}
+
 export function isEligible(filePath: string | undefined): boolean {
     return filePath && filePath.includes("xmake.lua") && !filePath.includes(".xmake");
 }
@@ -49,7 +53,7 @@ export function parse(output: string): vscode.Diagnostic[] {
                 severity = vscode.DiagnosticSeverity.Warning;
             }
 
-            if (isEligible(file) &&
+            if (!isInternalFile(file) &&
                 (severity == vscode.DiagnosticSeverity.Error ||
                  severity == vscode.DiagnosticSeverity.Warning)) {
                 let diag = new vscode.Diagnostic(


### PR DESCRIPTION
It seems that apart from xmake.lua, `xmake check` also output warnings/errors from internal files, which could be confusing, since they're not visible to users

This removes them from diagnosis info

![image](https://user-images.githubusercontent.com/1519585/226783090-b32b97af-f6b1-493a-a9e3-0eb6071ad0e5.png)
