### PR TITLE
Clear diagnosis before updates

### DIFF
--- a/src/xmake.ts
+++ b/src/xmake.ts
@@ -177,20 +177,10 @@ export class XMake implements vscode.Disposable {
         log.verbose("updating Diagnosis ..");
         const result = await process.runv(config.executable, ["check"], { "COLORTERM": "nocolor" }, config.workingDirectory);
         const diags = diagnosis.parse(result.stdout ?? result.stderr);
+        this._xmakeDiagnosticCollection.clear();
         for (const file in diags) {
             const uri = vscode.Uri.file(path.join(config.workingDirectory, file));
             this._xmakeDiagnosticCollection.set(uri, diags[file]);
-        }
-    }
-
-    async deleteDiagnosis(affectedPath: vscode.Uri|undefined) {
-        if (!diagnosis.isEligible(affectedPath?.fsPath)) {
-            return;
-        }
-
-        log.verbose("deleting Diagnosis ..");
-        if (this._xmakeDiagnosticCollection.has(affectedPath)) {
-            this._xmakeDiagnosticCollection.delete(affectedPath);
         }
     }
 
@@ -212,7 +202,6 @@ export class XMake implements vscode.Disposable {
         this._projectFileSystemWatcher = vscode.workspace.createFileSystemWatcher("**/xmake.lua");
         this._projectFileSystemWatcher.onDidCreate(this.onProjectFileUpdated.bind(this));
         this._projectFileSystemWatcher.onDidChange(this.onProjectFileUpdated.bind(this));
-        this._projectFileSystemWatcher.onDidDelete(this.onProjectFileDeleted.bind(this));
 
         this._context.subscriptions.push(
             vscode.workspace.onDidCreateFiles((e: vscode.FileCreateEvent) => {
@@ -292,11 +281,6 @@ export class XMake implements vscode.Disposable {
         }
 
         this.updateDiagnosis(affectedPath);
-    }
-
-    // on Project File Deleted
-    async onProjectFileDeleted(affectedPath: vscode.Uri) {
-        this.deleteDiagnosis(affectedPath);
     }
 
     // on Log File Updated


### PR DESCRIPTION
Since for now `xmake check` is running at root and it generates warnings/errors for all included xmake.lua, it is better clear diagnosis every time before it's updated

and `onDidDelete` event is no longer needed