### PR TITLE
fix #215 random target is run when you debug

### DIFF
--- a/src/launchDebugger.ts
+++ b/src/launchDebugger.ts
@@ -56,6 +56,8 @@ async function getTargets(): Promise<Array<string>> {
  * @returns TargetInformations
  */
 async function getInformations(targetName: string): Promise<TargetInformations> {
+    // below line fix #215
+    targetName = targetName.endsWith("\r") ? targetName.slice(0, -1) : targetName;
     let getTargetInformationsScript = path.join(__dirname, `../../assets/target_informations.lua`);
     if (fs.existsSync(getTargetInformationsScript)) {
         let targetInformations = (await process.iorunv(settings.executable, ["l", getTargetInformationsScript, targetName], { "COLORTERM": "nocolor" }, settings.workingDirectory)).stdout.trim();


### PR DESCRIPTION
the problems is in
https://github.com/xmake-io/xmake-vscode/blob/8274b8fdcab2e9cfb9549de55a53eaae40233de4/src/launchDebugger.ts#L40-L47

targets.lua return example
```json
[
  "cast\r",
  "decay\r",
  "declaration\r",
  "free_heap_lib\r",
  "function_pointers\r",
  "lambda\r",
  "memmove\r",
  "miscellaneous\r",
  "move_semantics\r",
  "os_stream\r",
  "pointers\r",
  "raw_bytes\r",
  "raw_bytes_lib\r",
  "references\r",
  "return_optimization\r",
  "rvalue\r",
  "smart_pointers\r",
  "templates\r",
  "temporary\r",
  "trivially\r",
  "utils_lib\r",
  "wmemcpy",
]
```
\r is using a delimiter for each target.
getInformations is called in
https://github.com/xmake-io/xmake-vscode/blob/8274b8fdcab2e9cfb9549de55a53eaae40233de4/src/launchDebugger.ts#L164-L176
where getInformations gets the targetName from getTargets, that contains \r in the end make it return the wrong target.

I don't like this fix much but seems like the proper way to do, because change the behavior of the targets.lua to no return \r feels error prone.