### PR TITLE
Fixed targetName == "all" never matched

### DIFF
--- a/src/xmake.ts
+++ b/src/xmake.ts
@@ -643,10 +643,10 @@ export class XMake implements vscode.Disposable {
         }
 
         // add build target to command
-        if (targetName && targetName != "default") {
-            args.push(targetName);
-        } else if (targetName == "all") {
+        if (targetName && targetName == "all") {
             args.push("-a");
+        } else if (targetName && targetName != "default") {
+            args.push(targetName);
         }
 
         // configure and build it


### PR DESCRIPTION
问题：在Status bar选择All Targets后Build按钮无法构建全部Targets
<img width="659" alt="image" src="https://github.com/xmake-io/xmake-vscode/assets/57782331/7c8acaf6-30a8-40d4-bc63-b3ac2cfba301">

原因：在onBuild函数中targetName == "all"时会匹配到第一个分支，把all当作项目名称了，"-a"选项也就没被添加
