### PR TITLE
Set path to compileCommands automatically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,27 +99,6 @@ Please see [xmake-github](https://github.com/xmake-io/xmake) and [website](http:
 
 ## IntelliSense
 
-xmake-vscode will generate `.vscode/compile_commands.json` file, so you need only add it to `.vscode/c_cpp_properties.json` to enable IntelliSense.
-
-for example (`.vscode/c_cpp_properties.json`):
-
-```json
-{
-    "configurations": [
-        {
-            "compileCommands": ".vscode/compile_commands.json"
-        }
-    ],
-    "version": 4
-}
-```
-
-### How can I generate c_cpp_properties.json?
-
-These configuration settings are stored in your project's c_cpp_properties.json file. To edit this file, in VS Code, select C/C++: Edit Configurations (UI) from the Command Palette (⇧⌘P):
-
-Please see [IntelliSense for cross-compiling](https://code.visualstudio.com/docs/cpp/configure-intellisense-crosscompilation)
-
 ![](https://code.visualstudio.com/assets/docs/cpp/cpp/command-palette.png)
 
 ## Debugging

--- a/src/xmake.ts
+++ b/src/xmake.ts
@@ -256,6 +256,19 @@ export class XMake implements vscode.Disposable {
         this._projectFileSystemWatcher.onDidCreate(this.onProjectFileUpdated.bind(this));
         this._projectFileSystemWatcher.onDidChange(this.onProjectFileUpdated.bind(this));
 
+        const compileCommandsFile = path.join(config.compileCommandsDirectory, "compile_commands.json");
+        const compileCommandsWatcher = vscode.workspace.createFileSystemWatcher(compileCommandsFile);
+        compileCommandsWatcher.onDidCreate(() => {
+            const config = vscode.workspace.getConfiguration('C_Cpp');
+            config.update("default.compileCommands", compileCommandsFile, vscode.ConfigurationTarget.Workspace);
+        });
+        this._context.subscriptions.push(compileCommandsWatcher);
+
+        if (fs.existsSync(compileCommandsFile)) {
+            const config = vscode.workspace.getConfiguration('C_Cpp');
+            config.update("default.compileCommands", compileCommandsFile, vscode.ConfigurationTarget.Workspace);
+        }
+
         this._context.subscriptions.push(
             vscode.workspace.onDidCreateFiles((e: vscode.FileCreateEvent) => {
                 this._xmakeExplorer.refresh();


### PR DESCRIPTION
I'm not sure if this is a feature or a bug fix, but this removes the need for setting the path to the compile commands file in `.vscode/c_cpp_properties.json` by setting `C_Cpp.default.compileCommands`.

With this, IntelliSense should work as soon as XMake is run for the first time.