### PR TITLE
Safer LUA -> vscode communication via stdout

### DIFF
--- a/assets/apis.lua
+++ b/assets/apis.lua
@@ -16,6 +16,9 @@ function main()
         json.mark_as_array(result)
     end
     local localjson =  json.encode(result)
+
+    -- denote the start of vscode information to ignore anything logging to stdout before this point
+    print("__begin__")
     print(localjson)
 
     -- print end tag to ignore other deprecated/warnings infos

--- a/assets/archs.lua
+++ b/assets/archs.lua
@@ -7,6 +7,9 @@ function main (plat)
 
     config.load()
     local archs = platform.archs(plat or config.get("plat"))
+
+    -- denote the start of vscode information to ignore anything logging to stdout before this point
+    print("__begin__")
     if archs then
         for _, arch in ipairs(archs) do
             print(arch)

--- a/assets/config.lua
+++ b/assets/config.lua
@@ -6,6 +6,9 @@ function main ()
 
     -- load config
     config.load()
+    
+    -- denote the start of vscode information to ignore anything logging to stdout before this point
+    print("__begin__")
 
     -- print config
     print("{\"plat\":\"$(plat)\", \"arch\":\"$(arch)\", \"mode\":\"$(mode)\"}")

--- a/assets/debuggable_targets.lua
+++ b/assets/debuggable_targets.lua
@@ -20,6 +20,9 @@ function main ()
         json.mark_as_array(names)
     end
     local localjson =  json.encode(names)
+    
+    -- denote the start of vscode information to ignore anything logging to stdout before this point
+    print("__begin__")
     print(localjson)
 
     -- print end tag to ignore other deprecated/warnings infos

--- a/assets/default_target.lua
+++ b/assets/default_target.lua
@@ -12,6 +12,8 @@ function main ()
     for _, target in pairs(project.targets()) do
         local default = target:get("default")
         if (default == nil or default == true) and target:get("kind") == "binary" then
+            -- denote the start of vscode information to ignore anything logging to stdout before this point
+            print("__begin__")
             print(target:name()) 
             break
         end

--- a/assets/modes.lua
+++ b/assets/modes.lua
@@ -7,6 +7,9 @@ function main (plat)
 
     config.load()
     local modes = project.modes() or {"release", "debug"}
+    
+    -- denote the start of vscode information to ignore anything logging to stdout before this point
+    print("__begin__")
     if modes then
         for _, mode in ipairs(modes) do
             print(mode)

--- a/assets/plats.lua
+++ b/assets/plats.lua
@@ -5,6 +5,9 @@ import("core.platform.platform")
 function main ()
 
     local plats = platform.plats()
+    
+    -- denote the start of vscode information to ignore anything logging to stdout before this point
+    print("__begin__")
     if plats then
         for _, plat in ipairs(plats) do
             print(plat)

--- a/assets/target_informations.lua
+++ b/assets/target_informations.lua
@@ -92,6 +92,9 @@ function main(targetname)
     infos["envs"] = _get_envs(target)
     infos["path"] = _get_path(target)
     infos["name"] = _get_name(target)
+    
+    -- denote the start of vscode information to ignore anything logging to stdout before this point
+    print("__begin__")
 
     print(json.encode(infos))
 

--- a/assets/target_rundir.lua
+++ b/assets/target_rundir.lua
@@ -25,6 +25,9 @@ function main (targetname)
             end
         end
     end
+    
+    -- denote the start of vscode information to ignore anything logging to stdout before this point
+    print("__begin__")
 
     -- get run directory
     if target then

--- a/assets/target_runenvs.lua
+++ b/assets/target_runenvs.lua
@@ -104,6 +104,9 @@ function main (targetname)
     if json.mark_as_array then
         json.mark_as_array(envirnoments)
     end
+
+    -- denote the start of vscode information to ignore anything logging to stdout before this point
+    print("__begin__")
     if not empty then
         print(json.encode(envirnoments))
     else

--- a/assets/targetpath.lua
+++ b/assets/targetpath.lua
@@ -24,6 +24,9 @@ function main (targetname)
             end
         end
     end
+    
+    -- denote the start of vscode information to ignore anything logging to stdout before this point
+    print("__begin__")
 
     -- get target path
     if target then

--- a/assets/targets.lua
+++ b/assets/targets.lua
@@ -19,6 +19,9 @@ function main ()
         json.mark_as_array(names)
     end
     local localjson =  json.encode(names)
+
+    -- denote the start of vscode information to ignore anything logging to stdout before this point
+    print("__begin__")
     print(localjson)
 
     -- print end tag to ignore other deprecated/warnings infos

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -24,8 +24,7 @@ function getXMakeCommandList(): Promise<string> {
             let result = (await process.iorunv(config.executable, ["l", getApisScript], { "COLORTERM": "nocolor" },
                 config.workingDirectory)).stdout.trim();
             if (result) {
-                result = result.split('__end__')[0].trim();
-                let resultJson = JSON.parse(result);
+                let resultJson = process.getAnnotatedJSON(result)[0];
                 if (resultJson && resultJson.length > 0) {
                     resolve(resultJson.join('\n'));
                     return;

--- a/src/launchDebugger.ts
+++ b/src/launchDebugger.ts
@@ -42,12 +42,9 @@ async function getDebuggableTargets(): Promise<Array<string>> {
     let getTargetsPathScript = path.join(__dirname, `../../assets/debuggable_targets.lua`);
     if (fs.existsSync(getTargetsPathScript)) {
         targets = (await process.iorunv(settings.executable, ["l", getTargetsPathScript], { "COLORTERM": "nocolor" }, settings.workingDirectory)).stdout.trim();
-        if (targets) {
-            targets = targets.split("__end__")[0].trim();
-        }
     }
     if (targets) {
-        return JSON.parse(targets);
+        return process.getAnnotatedJSON(targets)[0];
     }
     return [];
 }
@@ -62,10 +59,8 @@ async function getInformations(targetName: string): Promise<TargetInformations> 
     if (fs.existsSync(getTargetInformationsScript)) {
         let targetInformations = (await process.iorunv(settings.executable, ["l", getTargetInformationsScript, targetName], { "COLORTERM": "nocolor" }, settings.workingDirectory)).stdout.trim();
         if (targetInformations) {
-            targetInformations = targetInformations.split("__end__")[0].trim();
-            targetInformations = targetInformations.split('\n')[0].trim();
+            return process.getAnnotatedJSON(targetInformations)[0];
         }
-        return JSON.parse(targetInformations);
     }
 
     return null;

--- a/src/process.ts
+++ b/src/process.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import * as proc from 'child_process';
 import * as fs from 'fs';
 import * as convertor  from './bytes2string';
+import * as utils from './utils';
 import {log} from './log';
 
 // the execution result interface
@@ -155,4 +156,21 @@ export function execv(program: string, args: string[], env: {[key: string]: stri
             resolve({retval, stdout: acc.stdout, stderr: acc.stderr});
         })
     });
+}
+
+// Parse annotated output groups from a process where meaningful data is wrapped in
+// __begin__ and __end__.
+export function getAnnotatedOutput(result: string): Array<string>
+{
+    const regex = /__begin__(?<DATA>.*)__end__/gms;
+    let matches = [...result.matchAll(regex)];
+    return matches.map((m) => m.groups.DATA.trim());
+}
+
+// Get the blocks of json from process output wrapped in __begin__ and __end__
+export function getAnnotatedJSON(result: string): Array<any>
+{
+    return getAnnotatedOutput(result)
+        .filter(utils.isJson)
+        .map(o => JSON.parse(o));
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,5 +37,15 @@ export function replaceVars(str: string): string {
     return replacements.reduce((accdir, [needle, what]) => replaceAll(accdir, needle, what), str);
 }
 
+// simplistic function for just checking if a string can be parsed as json
+export function isJson(text?: string): boolean {
+    try {
+        JSON.parse(text);
+    } catch(e) {
+        return false;
+    }
+    return true;
+}
+
 // sleep some times
 export const sleep = ms => new Promise(res => setTimeout(res, ms));


### PR DESCRIPTION
I noticed a problem during using the xmake vscode extension, that commands which rely on JSON passed to vscode on stdout might fail if anything else is logged before the JSON parts. In my case the combo of `XMake.onDebug` and `target_runenvs.lua` was the culprit, where if the project uses native modules, the build status of them are also logged before `target_runenvs.lua` prints its output JSON. As a result the build output text is also passed to `JSON.parse` which then of course fails.

To fix these kinds of issues this PR adds `__begin__` annotations as well where `__end__` annotations were printed by lua, and introduces `process.getAnnotatedOutput` and `process.getAnnotatedJSON` to reduce boilerplate for processing the lua stdout ouptut. With the extra annotation logs printed before the intended information can be safely ignored.

The lua scripts are only modified to add `print("__begin__")`.

I didn't find automated tests, so I tested my PR on my personal project.