### PR TITLE
add dll debug support

### DIFF
--- a/src/launchDebugger.ts
+++ b/src/launchDebugger.ts
@@ -172,6 +172,12 @@ class XmakeConfigurationProvider implements vscode.DebugConfigurationProvider {
 
         const targetInformations = await getInformations(config.target);
 
+        // if target is a program full path,pass it.
+        if (fs.existsSync(config.target))
+        {
+            targetInformations.path = config.target;
+        }
+
         // Set the program path
         if (!(targetInformations.path && fs.existsSync(targetInformations.path))) {
             await vscode.window.showErrorMessage('The target program not found!');


### PR DESCRIPTION
Detail:if target is a program full path,then pass it.
so we can debug a dll by lanuch a third exe.
eg.
```
{
    "version": "0.2.0",
    "configurations": [
    
        {
            "type": "xmake",
            "request": "launch",
            "name": "launch exe to debug dll",
            "target": "D:\\xxx.exe",
            "cwd": "${workspaceFolder}",
            "stopAtEntry": false,
        }
    ]
}
```


